### PR TITLE
renovate: Remove forks configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,5 @@
 {
 	"extends": [
 		"github>balena-os/renovate-config"
-	],
-	"includeForks": true
+	]
 }


### PR DESCRIPTION
It's not needed now that we agreed not to use forks.

Changelog-entry: Remove forks configuration from renovate
Signed-off-by: Alex Gonzalez <alexg@balena.io>